### PR TITLE
Updated opc5ls papilio one build to 16K words of RAM

### DIFF
--- a/opc5/opc5system/ram_16k_16.v
+++ b/opc5/opc5system/ram_16k_16.v
@@ -1,8 +1,5 @@
 module ram ( input[15:0] din, output reg [15:0] dout, input[13:0] address, input rnw, input clk, input cs_b);
 
-   wire en = !cs_b;
-   wire we = !rnw;
-     
    parameter MEM_INIT_FILE = "";
 
    reg [15:0] ram [0:16383];

--- a/opc5ls/opc5system/opc5system.v
+++ b/opc5ls/opc5system/opc5system.v
@@ -8,7 +8,7 @@ module opc5system ( input clk, input[7:0] sw, output[7:0] led, input rxd, output
    parameter BAUD = 115200;
 
    // RAMSIZE is the size of the RAM address bus
-   parameter RAMSIZE = 11;
+   parameter RAMSIZE = 14;
    
    // Duty Cycle controls the brightness of the seven segment display (0..15)
    parameter SEVEN_SEG_DUTY_CYCLE = 0;

--- a/opc5ls/opc5system/papilio_one/opc5system.bmm
+++ b/opc5ls/opc5system/papilio_one/opc5system.bmm
@@ -1,10 +1,24 @@
 ADDRESS_MAP opcmap PPC405 0
 
-    ADDRESS_SPACE rom_code RAMB16 [0x00000000:0x00000fff]
+    ADDRESS_SPACE rom_code RAMB16 [0x00000000:0x00007fff]
 
         BUS_BLOCK
-            RAM/ram1 [15:8];
-            RAM/ram0 [7:0];
+            RAM/Mram_ram16 [15];
+            RAM/Mram_ram15 [14];
+            RAM/Mram_ram14 [13];
+            RAM/Mram_ram13 [12];
+            RAM/Mram_ram12 [11];
+            RAM/Mram_ram11 [10];
+            RAM/Mram_ram10 [9];
+            RAM/Mram_ram9 [8];
+            RAM/Mram_ram8 [7];
+            RAM/Mram_ram7 [6];
+            RAM/Mram_ram6 [5];
+            RAM/Mram_ram5 [4];
+            RAM/Mram_ram4 [3];
+            RAM/Mram_ram3 [2];
+            RAM/Mram_ram2 [1];
+            RAM/Mram_ram1 [0];
         END_BUS_BLOCK;
 
     END_ADDRESS_SPACE;

--- a/opc5ls/opc5system/papilio_one/opc5system.xise
+++ b/opc5ls/opc5system/papilio_one/opc5system.xise
@@ -26,13 +26,6 @@
     <file xil_pn:name="opc5system.ucf" xil_pn:type="FILE_UCF">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
-    <file xil_pn:name="opc5system.bmm" xil_pn:type="FILE_BMM">
-      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
-    </file>
-    <file xil_pn:name="../../../opc5/opc5system/ram_2k_16.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="6"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="4"/>
-    </file>
     <file xil_pn:name="../../../opc5/opc5system/sevenseg.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="7"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="3"/>
@@ -40,6 +33,13 @@
     <file xil_pn:name="../../../opc5/opc5system/uart.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="8"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="2"/>
+    </file>
+    <file xil_pn:name="../../../opc5/opc5system/ram_16k_16.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="56"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="4"/>
+    </file>
+    <file xil_pn:name="opc5system.bmm" xil_pn:type="FILE_BMM">
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
   </files>
 
@@ -67,7 +67,7 @@
     <property xil_pn:name="Change Device Speed To" xil_pn:value="-5" xil_pn:valueState="default"/>
     <property xil_pn:name="Change Device Speed To Post Trace" xil_pn:value="-5" xil_pn:valueState="default"/>
     <property xil_pn:name="Combinatorial Logic Optimization" xil_pn:value="false" xil_pn:valueState="default"/>
-    <property xil_pn:name="Compile EDK Simulation Library" xil_pn:value="true" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Compile EDK Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile SIMPRIM (Timing) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile UNISIM (Functional) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile XilinxCoreLib (CORE Generator) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>


### PR DESCRIPTION
This updates the Papilio build to 16K words of RAM, like the other two builds.