### PR TITLE
Monitor

### DIFF
--- a/opc5ls/monitor.s
+++ b/opc5ls/monitor.s
@@ -294,7 +294,7 @@ store_operand:
 
     ld      r7, r5, reg_state      # load the src register value
     ld      r8, r6, reg_state      # load the dst register value
-    ld      r9, r0, reg_state_psr  # load the c (bit 1) and z (bit 0) flags
+    ld      r9, r0, reg_state_psr  # load the s (bit 2), c (bit 1) and z (bit 0) flags
 
     psr     psr, r9                # load the flags
 
@@ -305,7 +305,9 @@ operand:
     WORD    0x0000                 # emulated opcode patched here
 
     psr     r9, psr                # save the flags
-    sto     r9, r0, reg_state_psr
+
+    cmp     r6, r0, 15             # was the destination register r15
+    nz.sto  r9, r0, reg_state_psr  # no, then save the flags
 
     sto     r8, r6, reg_state      # save the new dst register value
 

--- a/opc5ls/monitor.s
+++ b/opc5ls/monitor.s
@@ -250,14 +250,13 @@ dis_loop:
 # r7 is the patched source register
 # r8 is the patched destination register
 # r9 is the emulated flags
-
+# r10 is the iteration count
 
 step:
+    mov     r10, r5, 1             # iteration count + 1
 
-    JSR     (osnewl)
-    mov     r1, r4                 # display the next instruction
-    JSR     (disassemble)
-    JSR     (osnewl)
+step_loop:
+    JSR     (print_state)
 
     ld      r1, r4                 # fetch the instruction
     add     r4, r0, 1              # increment the PC
@@ -310,8 +309,12 @@ operand:
 
     sto     r8, r6, reg_state      # save the new dst register value
 
-    JSR     (print_regs)           # display the saved registers
     ld      r4, r0, reg_state_pc   # load the PC (r5)
+
+    sub     r10, r0, 1             # decrement the iteration count
+    nz.mov  pc, r0, step_loop      # and loop back for more instructions
+
+    JSR     (print_state)          # print the final state
 
     mov     pc, r0, m1             # back to the - prompt
 
@@ -320,6 +323,12 @@ regs:
     JSR     (print_regs)
     mov     pc, r0, m1             # back to the - prompt
 
+print_state:
+    JSR     (osnewl)
+    mov     r1, r4                 # display the next instruction
+    JSR     (disassemble)
+    JSR     (osnewl)
+    # fall through into print_regs
 
 # --------------------------------------------------------------
 #

--- a/opc5ls/monitor.s
+++ b/opc5ls/monitor.s
@@ -754,37 +754,37 @@ opcodes:
 reg_state:
     WORD 0x0000
 reg_state_r1:
-    WORD 0x1111
+    WORD 0x0000
 reg_state_r2:
-    WORD 0x2222
+    WORD 0x0000
 reg_state_r3:
-    WORD 0x3333
+    WORD 0x0000
 reg_state_r4:
-    WORD 0x4444
+    WORD 0x0000
 reg_state_r5:
-    WORD 0x5555
+    WORD 0x0000
 reg_state_r6:
-    WORD 0x6666
+    WORD 0x0000
 reg_state_r7:
-    WORD 0x7777
+    WORD 0x0000
 reg_state_r8:
-    WORD 0x8888
+    WORD 0x0000
 reg_state_r9:
-    WORD 0x9999
+    WORD 0x0000
 reg_state_r10:
-    WORD 0xaaaa
+    WORD 0x0000
 reg_state_r11:
-    WORD 0xbbbb
+    WORD 0x0000
 reg_state_r12:
-    WORD 0xcccc
+    WORD 0x0000
 reg_state_r13:
-    WORD 0xdddd
+    WORD 0x0000
 reg_state_r14:
-    WORD 0xeeee
+    WORD 0x0000
 reg_state_pc:
-    WORD 0xffff
+    WORD 0x0000
 reg_state_psr:
-    WORD 0x0002
+    WORD 0x0000
 
 # ----------------------------------------------------
 # Some test code (fastfib)

--- a/opc5ls/monitor.s
+++ b/opc5ls/monitor.s
@@ -187,7 +187,7 @@ go:
     mov     pc, r0, m1
 
 go1:
-    WORD    0xD00F   # mov pc, r0, ...
+    WORD    0x100F   # mov pc, r0, ...
 go2:
     WORD    0x0000
 
@@ -285,7 +285,7 @@ step:
     mov     pc, r0, store_operand
 
 no_operand:
-    mov     r1, r0, 0xE200         # operand slot is filled with a nop
+    mov     r1, r0, 0x2200         # operand slot is filled with a nop
                                    #   0.and   r0, r0
 store_operand:
     sto     r1, r0, operand        # store the operand

--- a/opc5ls/monitor.s
+++ b/opc5ls/monitor.s
@@ -350,6 +350,12 @@ no_newline:
     sub      r3, r0, 1
     nz.mov   pc, r0, dr_loop
 
+    mov      r1, r0, 0x73          # s
+    ld       r2, r0, reg_state_psr
+    ror      r2, r2
+    ror      r2, r2
+    JSR      (print_flag)
+
     mov      r1, r0, 0x63          # c
     ld       r2, r0, reg_state_psr
     ror      r2, r2
@@ -359,7 +365,7 @@ no_newline:
     ld       r2, r0, reg_state_psr
 
 print_flag:
-    JSR      (oswrch)              # "c" or "z"
+    JSR      (oswrch)              # "s" or "c" or "z"
     mov      r1, r0, 0x3d          # "="
     JSR      (oswrch)
     mov      r1, r2


### PR DESCRIPTION
Changes to monitor to align the single stepper output format with the emulator.

Also, add an instruction count:
- 1000@
- 0010s

Will single step 0x10 instructions starting at 0x1000

Also fixes the single stepper flag corruption bug (when dst=pc)
