### PR TITLE
system: corrected default A/D size for opc5ls/opc5

### DIFF
--- a/system/blackice/system_tb.v
+++ b/system/blackice/system_tb.v
@@ -133,7 +133,7 @@ system
 
    always @(posedge DUT.clk)
      if (DUT.cpuclken) begin
-        if (DUT.vda && !DUT.rnw && DUT.address[15:0] == 16'hfe09)
+        if (DUT.vio && !DUT.rnw && DUT.address[15:0] == 16'hfe09)
           if (DUT.cpu_dout == 10)
             $display("%t: UART Tx:  <lf>", $time);
           else if (DUT.cpu_dout == 13)

--- a/system/src/system.v
+++ b/system/src/system.v
@@ -26,8 +26,8 @@ module system ( input clk, input[7:0] sw, output[7:0] led, input rxd, output txd
    parameter ASIZE   = 20;
    parameter RAMSIZE = 13;
 `else
-   parameter DSIZE   = 32;
-   parameter ASIZE   = 20;
+   parameter DSIZE   = 16;
+   parameter ASIZE   = 16;
    parameter RAMSIZE = 14;
 `endif
 


### PR DESCRIPTION
Sorry, one small error in the previous pull request...

Change-Id: Icd2cddc2111bd1668f56ccfa5d72b5ff09535219